### PR TITLE
Add tenant/domain models and multi-tenant support

### DIFF
--- a/autogenstudio/datamodel/__init__.py
+++ b/autogenstudio/datamodel/__init__.py
@@ -1,4 +1,15 @@
-from .db import BaseDBModel, Gallery, Message, Run, RunStatus, Session, Settings, Team
+from .db import (
+    BaseDBModel,
+    Domain,
+    Gallery,
+    Message,
+    Run,
+    RunStatus,
+    Session,
+    Settings,
+    Team,
+    Tenant,
+)
 from .types import (
     EnvironmentVariable,
     GalleryComponents,
@@ -14,6 +25,7 @@ from .types import (
 )
 
 __all__ = [
+    "BaseDBModel",
     "Team",
     "Run",
     "RunStatus",
@@ -33,4 +45,6 @@ __all__ = [
     "Settings",
     "EnvironmentVariable",
     "Gallery",
+    "Tenant",
+    "Domain",
 ]

--- a/autogenstudio/datamodel/db.py
+++ b/autogenstudio/datamodel/db.py
@@ -47,6 +47,46 @@ class BaseDBModel(SQLModel, table=False):
     user_id: Optional[str] = None
     version: Optional[str] = "0.0.1"
 
+    tenant_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(Integer, ForeignKey("tenant.id", ondelete="CASCADE")),
+    )
+    domain_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(Integer, ForeignKey("domain.id", ondelete="SET NULL")),
+    )
+
+
+class Tenant(SQLModel, table=True):
+    __table_args__ = {"sqlite_autoincrement": True}
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    slug: str
+    config: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    created_at: datetime = Field(
+        default_factory=datetime.now,
+        sa_type=DateTime(timezone=True),
+        sa_column_kwargs={"server_default": func.now(), "nullable": True},
+    )
+
+
+class Domain(SQLModel, table=True):
+    __table_args__ = {"sqlite_autoincrement": True}
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    tenant_id: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("tenant.id", ondelete="CASCADE"), nullable=False
+        )
+    )
+    created_at: datetime = Field(
+        default_factory=datetime.now,
+        sa_type=DateTime(timezone=True),
+        sa_column_kwargs={"server_default": func.now(), "nullable": True},
+    )
+
 
 class Team(BaseDBModel, table=True):
     __table_args__ = {"sqlite_autoincrement": True}
@@ -57,19 +97,29 @@ class Message(BaseDBModel, table=True):
     __table_args__ = {"sqlite_autoincrement": True}
 
     config: Union[MessageConfig, dict] = Field(
-        default_factory=lambda: MessageConfig(source="", content=""), sa_column=Column(JSON)
+        default_factory=lambda: MessageConfig(source="", content=""),
+        sa_column=Column(JSON),
     )
     session_id: Optional[int] = Field(
-        default=None, sa_column=Column(Integer, ForeignKey("session.id", ondelete="NO ACTION"))
+        default=None,
+        sa_column=Column(Integer, ForeignKey("session.id", ondelete="NO ACTION")),
     )
-    run_id: Optional[int] = Field(default=None, sa_column=Column(Integer, ForeignKey("run.id", ondelete="CASCADE")))
+    run_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(Integer, ForeignKey("run.id", ondelete="CASCADE")),
+    )
 
-    message_meta: Optional[Union[MessageMeta, dict]] = Field(default={}, sa_column=Column(JSON))
+    message_meta: Optional[Union[MessageMeta, dict]] = Field(
+        default={}, sa_column=Column(JSON)
+    )
 
 
 class Session(BaseDBModel, table=True):
     __table_args__ = {"sqlite_autoincrement": True}
-    team_id: Optional[int] = Field(default=None, sa_column=Column(Integer, ForeignKey("team.id", ondelete="CASCADE")))
+    team_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(Integer, ForeignKey("team.id", ondelete="CASCADE")),
+    )
     name: Optional[str] = None
 
     @field_validator("created_at", "updated_at", mode="before")
@@ -93,19 +143,26 @@ class Run(BaseDBModel, table=True):
 
     __table_args__ = {"sqlite_autoincrement": True}
 
-    session_id: int = Field(sa_column=Column(Integer, ForeignKey("session.id", ondelete="CASCADE"), nullable=False))
+    session_id: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("session.id", ondelete="CASCADE"), nullable=False
+        )
+    )
     status: RunStatus = Field(default=RunStatus.CREATED)
 
     # Store the original user task
     task: Union[MessageConfig, dict] = Field(
-        default_factory=lambda: MessageConfig(source="", content=""), sa_column=Column(JSON)
+        default_factory=lambda: MessageConfig(source="", content=""),
+        sa_column=Column(JSON),
     )
 
     # Store TeamResult which contains TaskResult
     team_result: Union[TeamResult, dict] = Field(default=None, sa_column=Column(JSON))
 
     error_message: Optional[str] = None
-    messages: Union[List[Message], List[dict]] = Field(default_factory=list, sa_column=Column(JSON))
+    messages: Union[List[Message], List[dict]] = Field(
+        default_factory=list, sa_column=Column(JSON)
+    )
 
     model_config = ConfigDict(json_encoders={datetime: lambda v: v.isoformat()})  # type: ignore[call-arg]
 
@@ -118,7 +175,14 @@ class Gallery(BaseDBModel, table=True):
             id="",
             name="",
             metadata=GalleryMetadata(author="", version=""),
-            components=GalleryComponents(agents=[], models=[], tools=[], terminations=[], teams=[], workbenches=[]),
+            components=GalleryComponents(
+                agents=[],
+                models=[],
+                tools=[],
+                terminations=[],
+                teams=[],
+                workbenches=[],
+            ),
         ),
         sa_column=Column(JSON),
     )
@@ -134,7 +198,9 @@ class Gallery(BaseDBModel, table=True):
 class Settings(BaseDBModel, table=True):
     __table_args__ = {"sqlite_autoincrement": True}
 
-    config: Union[SettingsConfig, dict] = Field(default_factory=SettingsConfig, sa_column=Column(JSON))
+    config: Union[SettingsConfig, dict] = Field(
+        default_factory=SettingsConfig, sa_column=Column(JSON)
+    )
 
 
 # --- Evaluation system database models ---
@@ -170,7 +236,8 @@ class EvalRunDB(BaseDBModel, table=True):
 
     # References to related components
     task_id: Optional[int] = Field(
-        default=None, sa_column=Column(Integer, ForeignKey("evaltaskdb.id", ondelete="SET NULL"))
+        default=None,
+        sa_column=Column(Integer, ForeignKey("evaltaskdb.id", ondelete="SET NULL")),
     )
 
     # Serialized configurations for runner and judge
@@ -178,7 +245,9 @@ class EvalRunDB(BaseDBModel, table=True):
     judge_config: Union[ComponentModel, dict] = Field(sa_column=Column(JSON))
 
     # List of criteria IDs or embedded criteria configs
-    criteria_configs: List[Union[EvalJudgeCriteria, dict]] = Field(default_factory=list, sa_column=Column(JSON))
+    criteria_configs: List[Union[EvalJudgeCriteria, dict]] = Field(
+        default_factory=list, sa_column=Column(JSON)
+    )
 
     # Run status and timing information
     status: EvalRunStatus = Field(default=EvalRunStatus.PENDING)

--- a/autogenstudio/web/routes/gallery.py
+++ b/autogenstudio/web/routes/gallery.py
@@ -4,31 +4,54 @@ from fastapi import APIRouter, Depends, HTTPException
 from ...database import DatabaseManager
 from ...datamodel import Gallery, Response
 from ...gallery.builder import create_default_gallery
-from ..deps import get_db
+from ..deps import (
+    get_current_domain_id,
+    get_current_tenant_id,
+    get_db,
+)
 
 router = APIRouter()
 
 
 @router.put("/{gallery_id}")
 async def update_gallery_entry(
-    gallery_id: int, gallery_data: Gallery, user_id: str, db: DatabaseManager = Depends(get_db)
+    gallery_id: int,
+    gallery_data: Gallery,
+    user_id: str,
+    tenant_id: int = Depends(get_current_tenant_id),
+    domain_id: int = Depends(get_current_domain_id),
+    db: DatabaseManager = Depends(get_db),
 ) -> Response:
     # Check ownership first
-    result = db.get(Gallery, filters={"id": gallery_id})
+    result = db.get(
+        Gallery,
+        filters={"id": gallery_id, "tenant_id": tenant_id, "domain_id": domain_id},
+    )
     if not result.status or not result.data:
         raise HTTPException(status_code=404, detail="Gallery entry not found")
 
     if result.data[0].user_id != user_id:
-        raise HTTPException(status_code=403, detail="Not authorized to update this gallery entry")
+        raise HTTPException(
+            status_code=403, detail="Not authorized to update this gallery entry"
+        )
 
     # Update if authorized
     gallery_data.id = gallery_id  # Ensure ID matches
     gallery_data.user_id = user_id  # Ensure user_id matches
+    gallery_data.tenant_id = tenant_id
+    gallery_data.domain_id = domain_id
     return db.upsert(gallery_data)
 
 
 @router.post("/")
-async def create_gallery_entry(gallery_data: Gallery, db: DatabaseManager = Depends(get_db)) -> Response:
+async def create_gallery_entry(
+    gallery_data: Gallery,
+    tenant_id: int = Depends(get_current_tenant_id),
+    domain_id: int = Depends(get_current_domain_id),
+    db: DatabaseManager = Depends(get_db),
+) -> Response:
+    gallery_data.tenant_id = tenant_id
+    gallery_data.domain_id = domain_id
     response = db.upsert(gallery_data)
     if not response.status:
         raise HTTPException(status_code=400, detail=response.message)
@@ -36,23 +59,63 @@ async def create_gallery_entry(gallery_data: Gallery, db: DatabaseManager = Depe
 
 
 @router.get("/")
-async def list_gallery_entries(user_id: str, db: DatabaseManager = Depends(get_db)) -> Response:
+async def list_gallery_entries(
+    user_id: str,
+    tenant_id: int = Depends(get_current_tenant_id),
+    domain_id: int = Depends(get_current_domain_id),
+    db: DatabaseManager = Depends(get_db),
+) -> Response:
     try:
-        result = db.get(Gallery, filters={"user_id": user_id})
+        result = db.get(
+            Gallery,
+            filters={
+                "user_id": user_id,
+                "tenant_id": tenant_id,
+                "domain_id": domain_id,
+            },
+        )
         if not result.data or len(result.data) == 0:
             # create a default gallery entry
             gallery_config = create_default_gallery()
-            default_gallery = Gallery(user_id=user_id, config=gallery_config.model_dump())
+            default_gallery = Gallery(
+                user_id=user_id,
+                config=gallery_config.model_dump(),
+                tenant_id=tenant_id,
+                domain_id=domain_id,
+            )
             db.upsert(default_gallery)
-            result = db.get(Gallery, filters={"user_id": user_id})
+            result = db.get(
+                Gallery,
+                filters={
+                    "user_id": user_id,
+                    "tenant_id": tenant_id,
+                    "domain_id": domain_id,
+                },
+            )
         return result
     except Exception as e:
-        return Response(status=False, data=[], message=f"Error retrieving gallery entries: {str(e)}")
+        return Response(
+            status=False, data=[], message=f"Error retrieving gallery entries: {str(e)}"
+        )
 
 
 @router.get("/{gallery_id}")
-async def get_gallery_entry(gallery_id: int, user_id: str, db: DatabaseManager = Depends(get_db)) -> Response:
-    result = db.get(Gallery, filters={"id": gallery_id, "user_id": user_id})
+async def get_gallery_entry(
+    gallery_id: int,
+    user_id: str,
+    tenant_id: int = Depends(get_current_tenant_id),
+    domain_id: int = Depends(get_current_domain_id),
+    db: DatabaseManager = Depends(get_db),
+) -> Response:
+    result = db.get(
+        Gallery,
+        filters={
+            "id": gallery_id,
+            "user_id": user_id,
+            "tenant_id": tenant_id,
+            "domain_id": domain_id,
+        },
+    )
     if not result.status or not result.data:
         raise HTTPException(status_code=404, detail="Gallery entry not found")
 
@@ -60,12 +123,29 @@ async def get_gallery_entry(gallery_id: int, user_id: str, db: DatabaseManager =
 
 
 @router.delete("/{gallery_id}")
-async def delete_gallery_entry(gallery_id: int, user_id: str, db: DatabaseManager = Depends(get_db)) -> Response:
+async def delete_gallery_entry(
+    gallery_id: int,
+    user_id: str,
+    tenant_id: int = Depends(get_current_tenant_id),
+    domain_id: int = Depends(get_current_domain_id),
+    db: DatabaseManager = Depends(get_db),
+) -> Response:
     # Check ownership first
-    result = db.get(Gallery, filters={"id": gallery_id, "user_id": user_id})
+    result = db.get(
+        Gallery,
+        filters={
+            "id": gallery_id,
+            "user_id": user_id,
+            "tenant_id": tenant_id,
+            "domain_id": domain_id,
+        },
+    )
 
     if not result.status or not result.data:
         raise HTTPException(status_code=404, detail="Gallery entry not found")
-    response = db.delete(Gallery, filters={"id": gallery_id})
+    response = db.delete(
+        Gallery,
+        filters={"id": gallery_id, "tenant_id": tenant_id, "domain_id": domain_id},
+    )
     # Delete if authorized
     return response

--- a/autogenstudio/web/routes/settingsroute.py
+++ b/autogenstudio/web/routes/settingsroute.py
@@ -4,21 +4,49 @@ from typing import Dict
 from fastapi import APIRouter, Depends, HTTPException
 
 from ...datamodel import Settings, SettingsConfig
-from ..deps import get_db
+from ..deps import (
+    get_current_domain_id,
+    get_current_tenant_id,
+    get_db,
+)
 
 router = APIRouter()
 
 
 @router.get("/")
-async def get_settings(user_id: str, db=Depends(get_db)) -> Dict:
+async def get_settings(
+    user_id: str,
+    tenant_id: int = Depends(get_current_tenant_id),
+    domain_id: int = Depends(get_current_domain_id),
+    db=Depends(get_db),
+) -> Dict:
     try:
-        response = db.get(Settings, filters={"user_id": user_id})
+        response = db.get(
+            Settings,
+            filters={
+                "user_id": user_id,
+                "tenant_id": tenant_id,
+                "domain_id": domain_id,
+            },
+        )
         if not response.status or not response.data:
             # create a default settings
             config = SettingsConfig()
-            default_settings = Settings(user_id=user_id, config=config.model_dump())
+            default_settings = Settings(
+                user_id=user_id,
+                config=config.model_dump(),
+                tenant_id=tenant_id,
+                domain_id=domain_id,
+            )
             db.upsert(default_settings)
-            response = db.get(Settings, filters={"user_id": user_id})
+            response = db.get(
+                Settings,
+                filters={
+                    "user_id": user_id,
+                    "tenant_id": tenant_id,
+                    "domain_id": domain_id,
+                },
+            )
         # print(response.data[0])
         return {"status": True, "data": response.data[0]}
     except Exception as e:
@@ -26,7 +54,14 @@ async def get_settings(user_id: str, db=Depends(get_db)) -> Dict:
 
 
 @router.put("/")
-async def update_settings(settings: Settings, db=Depends(get_db)) -> Dict:
+async def update_settings(
+    settings: Settings,
+    tenant_id: int = Depends(get_current_tenant_id),
+    domain_id: int = Depends(get_current_domain_id),
+    db=Depends(get_db),
+) -> Dict:
+    settings.tenant_id = tenant_id
+    settings.domain_id = domain_id
     response = db.upsert(settings)
     if not response.status:
         raise HTTPException(status_code=400, detail=response.message)

--- a/autogenstudio/web/routes/teams.py
+++ b/autogenstudio/web/routes/teams.py
@@ -5,38 +5,83 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from ...datamodel import Team
 from ...gallery.builder import create_default_gallery
-from ..deps import get_db
+from ..deps import (
+    get_current_domain_id,
+    get_current_tenant_id,
+    get_db,
+)
 
 router = APIRouter()
 
 
 @router.get("/")
-async def list_teams(user_id: str, db=Depends(get_db)) -> Dict:
+async def list_teams(
+    user_id: str,
+    tenant_id: int = Depends(get_current_tenant_id),
+    domain_id: int = Depends(get_current_domain_id),
+    db=Depends(get_db),
+) -> Dict:
     """List all teams for a user"""
-    response = db.get(Team, filters={"user_id": user_id})
+    response = db.get(
+        Team,
+        filters={"user_id": user_id, "tenant_id": tenant_id, "domain_id": domain_id},
+    )
 
     if not response.data or len(response.data) == 0:
         default_gallery = create_default_gallery()
-        default_team = Team(user_id=user_id, component=default_gallery.components.teams[0].model_dump())
+        default_team = Team(
+            user_id=user_id,
+            component=default_gallery.components.teams[0].model_dump(),
+            tenant_id=tenant_id,
+            domain_id=domain_id,
+        )
 
         db.upsert(default_team)
-        response = db.get(Team, filters={"user_id": user_id})
+        response = db.get(
+            Team,
+            filters={
+                "user_id": user_id,
+                "tenant_id": tenant_id,
+                "domain_id": domain_id,
+            },
+        )
 
     return {"status": True, "data": response.data}
 
 
 @router.get("/{team_id}")
-async def get_team(team_id: int, user_id: str, db=Depends(get_db)) -> Dict:
+async def get_team(
+    team_id: int,
+    user_id: str,
+    tenant_id: int = Depends(get_current_tenant_id),
+    domain_id: int = Depends(get_current_domain_id),
+    db=Depends(get_db),
+) -> Dict:
     """Get a specific team"""
-    response = db.get(Team, filters={"id": team_id, "user_id": user_id})
+    response = db.get(
+        Team,
+        filters={
+            "id": team_id,
+            "user_id": user_id,
+            "tenant_id": tenant_id,
+            "domain_id": domain_id,
+        },
+    )
     if not response.status or not response.data:
         raise HTTPException(status_code=404, detail="Team not found")
     return {"status": True, "data": response.data[0]}
 
 
 @router.post("/")
-async def create_team(team: Team, db=Depends(get_db)) -> Dict:
+async def create_team(
+    team: Team,
+    tenant_id: int = Depends(get_current_tenant_id),
+    domain_id: int = Depends(get_current_domain_id),
+    db=Depends(get_db),
+) -> Dict:
     """Create a new team"""
+    team.tenant_id = tenant_id
+    team.domain_id = domain_id
     response = db.upsert(team)
     if not response.status:
         raise HTTPException(status_code=400, detail=response.message)
@@ -44,7 +89,21 @@ async def create_team(team: Team, db=Depends(get_db)) -> Dict:
 
 
 @router.delete("/{team_id}")
-async def delete_team(team_id: int, user_id: str, db=Depends(get_db)) -> Dict:
+async def delete_team(
+    team_id: int,
+    user_id: str,
+    tenant_id: int = Depends(get_current_tenant_id),
+    domain_id: int = Depends(get_current_domain_id),
+    db=Depends(get_db),
+) -> Dict:
     """Delete a team"""
-    db.delete(filters={"id": team_id, "user_id": user_id}, model_class=Team)
+    db.delete(
+        filters={
+            "id": team_id,
+            "user_id": user_id,
+            "tenant_id": tenant_id,
+            "domain_id": domain_id,
+        },
+        model_class=Team,
+    )
     return {"status": True, "message": "Team deleted successfully"}

--- a/frontend/src/auth/api.ts
+++ b/frontend/src/auth/api.ts
@@ -7,6 +7,7 @@ export interface User {
   avatar_url?: string;
   provider?: string;
   roles?: string[];
+  metadata?: Record<string, any>;
 }
 
 export class AuthAPI {

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -31,6 +31,7 @@ const Header = ({ meta, link }: any) => {
   const userName = user ? user.name : "Unknown";
   const userAvatarUrl = user ? sanitizeUrl(user.avatar_url) : "";
   const user_id = user ? user.id : "unknown";
+  const tenant_id = user?.metadata?.tenant_id;
 
   const links: any[] = [
     { name: "Build", href: "/build" },
@@ -146,6 +147,9 @@ const Header = ({ meta, link }: any) => {
                       <div className="ml-3">
                         <div className="text-sm text-primary">{userName}</div>
                         <div className="text-xs  text-secondary">{user_id}</div>
+                        {tenant_id && (
+                          <div className="text-xs text-secondary">Tenant: {tenant_id}</div>
+                        )}
                       </div>
 
                       {/* Profile dropdown */}
@@ -254,6 +258,9 @@ const Header = ({ meta, link }: any) => {
                   <div className="ml-3">
                     <div className="text-sm text-primary">{userName}</div>
                     <div className="text-xs   text-secondary">{user_id}</div>
+                    {tenant_id && (
+                      <div className="text-xs text-secondary">Tenant: {tenant_id}</div>
+                    )}
                   </div>
                   <button
                     type="button"

--- a/frontend/src/components/types/datamodel.ts
+++ b/frontend/src/components/types/datamodel.ts
@@ -418,6 +418,19 @@ export interface DBModel {
   created_at?: string;
   updated_at?: string;
   version?: number;
+  tenant_id?: number;
+  domain_id?: number;
+}
+
+export interface Tenant extends DBModel {
+  name: string;
+  slug: string;
+  config?: Record<string, any>;
+}
+
+export interface Domain extends DBModel {
+  name: string;
+  tenant_id: number;
 }
 
 export interface Message extends DBModel {

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -1,4 +1,4 @@
-import asyncio 
+import asyncio
 import pytest
 from sqlmodel import Session, text, select
 from typing import Generator
@@ -8,7 +8,16 @@ from autogen_agentchat.agents import AssistantAgent
 from autogen_agentchat.teams import RoundRobinGroupChat
 from autogen_ext.models.openai import OpenAIChatCompletionClient
 from autogen_agentchat.conditions import TextMentionTermination
-from autogenstudio.datamodel.db import Team, Session as SessionModel, Run, Message, RunStatus, MessageConfig
+from autogenstudio.datamodel.db import (
+    Team,
+    Session as SessionModel,
+    Run,
+    Message,
+    RunStatus,
+    MessageConfig,
+    Tenant,
+    Domain,
+)
 
 
 @pytest.fixture
@@ -38,10 +47,12 @@ def sample_team(test_user: str) -> Team:
         name="weather_agent",
         model_client=OpenAIChatCompletionClient(
             model="gpt-4.1-nano",
-        ), 
+        ),
     )
 
-    agent_team = RoundRobinGroupChat([agent], termination_condition=TextMentionTermination("TERMINATE"))
+    agent_team = RoundRobinGroupChat(
+        [agent], termination_condition=TextMentionTermination("TERMINATE")
+    )
     team_component = agent_team.dump_component()
 
     return Team(
@@ -54,7 +65,7 @@ class TestDatabaseOperations:
     def test_basic_setup(self, test_db: DatabaseManager):
         """Test basic database setup and connection"""
         with Session(test_db.engine) as session:
-            result = session.exec(text("SELECT 1")).first() # type: ignore
+            result = session.exec(text("SELECT 1")).first()  # type: ignore
             assert result[0] == 1
             result = session.exec(select(1)).first()
             assert result == 1
@@ -64,7 +75,7 @@ class TestDatabaseOperations:
         # Use upsert instead of raw session
         response = test_db.upsert(sample_team)
         assert response.status is True
-        
+
         with Session(test_db.engine) as session:
             saved_team = session.get(Team, sample_team.id)
             assert saved_team is not None
@@ -92,10 +103,10 @@ class TestDatabaseOperations:
         # First insert the model
         response = test_db.upsert(sample_team)
         assert response.status is True  # Verify insert worked
-        
+
         # Get the ID that was actually saved
         team_id = sample_team.id
-        
+
         # Test deletion by id
         response = test_db.delete(Team, {"id": team_id})
         assert response.status is True
@@ -104,8 +115,8 @@ class TestDatabaseOperations:
         # Verify deletion
         result = test_db.get(Team, {"id": team_id})
         if result.data:
-            assert len(result.data) == 0 
-        
+            assert len(result.data) == 0
+
     def test_cascade_delete(self, test_db: DatabaseManager, test_user: str):
         """Test all levels of cascade delete"""
         # Enable foreign keys for SQLite (crucial for cascade delete)
@@ -119,20 +130,26 @@ class TestDatabaseOperations:
         session1 = SessionModel(user_id=test_user, team_id=team1.id, name="Session1")
         test_db.upsert(session1)
         run1_id = 1
-        test_db.upsert(Run(
-            id=run1_id, 
-            user_id=test_user, 
-            session_id=session1.id or 1,  # Ensure session_id is not None
-            status=RunStatus.COMPLETE, 
-            task=MessageConfig(content="Task1", source="user").model_dump()
-        ))
-        test_db.upsert(Message(
-            user_id=test_user, 
-            session_id=session1.id, 
-            run_id=run1_id, 
-            config=MessageConfig(content="Message1", source="assistant").model_dump()
-        ))
-        
+        test_db.upsert(
+            Run(
+                id=run1_id,
+                user_id=test_user,
+                session_id=session1.id or 1,  # Ensure session_id is not None
+                status=RunStatus.COMPLETE,
+                task=MessageConfig(content="Task1", source="user").model_dump(),
+            )
+        )
+        test_db.upsert(
+            Message(
+                user_id=test_user,
+                session_id=session1.id,
+                run_id=run1_id,
+                config=MessageConfig(
+                    content="Message1", source="assistant"
+                ).model_dump(),
+            )
+        )
+
         test_db.delete(Run, {"id": run1_id})
         db_message = test_db.get(Message, {"run_id": run1_id})
         if db_message.data:
@@ -142,20 +159,26 @@ class TestDatabaseOperations:
         session2 = SessionModel(user_id=test_user, team_id=team1.id, name="Session2")
         test_db.upsert(session2)
         run2_id = 2
-        test_db.upsert(Run(
-            id=run2_id, 
-            user_id=test_user, 
-            session_id=session2.id or 2,  # Ensure session_id is not None
-            status=RunStatus.COMPLETE, 
-            task=MessageConfig(content="Task2", source="user").model_dump()
-        ))
-        test_db.upsert(Message(
-            user_id=test_user, 
-            session_id=session2.id, 
-            run_id=run2_id, 
-            config=MessageConfig(content="Message2", source="assistant").model_dump()
-        ))
-        
+        test_db.upsert(
+            Run(
+                id=run2_id,
+                user_id=test_user,
+                session_id=session2.id or 2,  # Ensure session_id is not None
+                status=RunStatus.COMPLETE,
+                task=MessageConfig(content="Task2", source="user").model_dump(),
+            )
+        )
+        test_db.upsert(
+            Message(
+                user_id=test_user,
+                session_id=session2.id,
+                run_id=run2_id,
+                config=MessageConfig(
+                    content="Message2", source="assistant"
+                ).model_dump(),
+            )
+        )
+
         test_db.delete(SessionModel, {"id": session2.id})
         session = test_db.get(SessionModel, {"id": session2.id})
         run = test_db.get(Run, {"id": run2_id})
@@ -171,9 +194,11 @@ class TestDatabaseOperations:
         """Test different initialize_database parameters"""
         db_path = tmp_path / "test_init.db"
         db = DatabaseManager(f"sqlite:///{db_path}", base_dir=tmp_path)
-        
+
         # Mock the schema manager's check_schema_status to avoid migration issues
-        monkeypatch.setattr(db.schema_manager, "check_schema_status", lambda: (False, None))
+        monkeypatch.setattr(
+            db.schema_manager, "check_schema_status", lambda: (False, None)
+        )
         monkeypatch.setattr(db.schema_manager, "ensure_schema_up_to_date", lambda: True)
 
         try:
@@ -187,4 +212,52 @@ class TestDatabaseOperations:
 
         finally:
             asyncio.run(db.close())
-            db.reset_db() 
+            db.reset_db()
+
+    def test_multi_tenant_filtering(self, test_db: DatabaseManager, sample_team: Team):
+        tenant1 = Tenant(name="Tenant1", slug="t1")
+        tenant2 = Tenant(name="Tenant2", slug="t2")
+        test_db.upsert(tenant1)
+        test_db.upsert(tenant2)
+
+        domain1 = Domain(name="Default", tenant_id=tenant1.id)
+        domain2 = Domain(name="Default", tenant_id=tenant2.id)
+        test_db.upsert(domain1)
+        test_db.upsert(domain2)
+
+        sample_team.tenant_id = tenant1.id
+        sample_team.domain_id = domain1.id
+        test_db.upsert(sample_team)
+
+        team2 = Team(
+            user_id=sample_team.user_id,
+            component=sample_team.component,
+            tenant_id=tenant2.id,
+            domain_id=domain2.id,
+        )
+        test_db.upsert(team2)
+
+        resp = test_db.get(Team, {"tenant_id": tenant1.id})
+        assert resp.status is True
+        assert all(t.tenant_id == tenant1.id for t in resp.data)
+
+        session1 = SessionModel(
+            user_id="u1",
+            team_id=sample_team.id,
+            name="S1",
+            tenant_id=tenant1.id,
+            domain_id=domain1.id,
+        )
+        session2 = SessionModel(
+            user_id="u1",
+            team_id=sample_team.id,
+            name="S2",
+            tenant_id=tenant2.id,
+            domain_id=domain2.id,
+        )
+        test_db.upsert(session1)
+        test_db.upsert(session2)
+
+        sess_resp = test_db.get(SessionModel, {"tenant_id": tenant1.id})
+        assert sess_resp.status is True
+        assert all(s.tenant_id == tenant1.id for s in sess_resp.data)


### PR DESCRIPTION
## Summary
- introduce `Tenant` and `Domain` database models
- add optional `tenant_id` and `domain_id` fields via `BaseDBModel`
- create default tenant/domain during manager initialization
- expose `get_current_tenant_id` and `get_current_domain_id` deps
- filter CRUD routes by tenant and domain
- test multi-tenant filtering for teams and sessions
- extend frontend data types to include tenant/domain info
- show active tenant in header

## Testing
- `ruff format autogenstudio/datamodel/__init__.py autogenstudio/datamodel/db.py autogenstudio/web/deps.py autogenstudio/web/routes/sessions.py autogenstudio/web/routes/teams.py autogenstudio/web/routes/runs.py autogenstudio/web/routes/gallery.py autogenstudio/web/routes/settingsroute.py tests/test_db_manager.py`
- `ruff check autogenstudio/datamodel/__init__.py autogenstudio/datamodel/db.py autogenstudio/web/deps.py autogenstudio/web/routes/sessions.py autogenstudio/web/routes/teams.py autogenstudio/web/routes/runs.py autogenstudio/web/routes/gallery.py autogenstudio/web/routes/settingsroute.py tests/test_db_manager.py`
- `pytest -n 0 --cov=autogenstudio --cov-report=term-missing` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_688bdabb6e008328993261f03e56c07d